### PR TITLE
Fix nil pointer dereference

### DIFF
--- a/gists/gist8018045/main.go
+++ b/gists/gist8018045/main.go
@@ -72,7 +72,7 @@ func getGoPackagesB(out chan<- ImportPathFound) {
 		}
 
 		_ = filepath.Walk(root, func(path string, fi os.FileInfo, _ error) error {
-			if !fi.IsDir() {
+			if fi == nil || !fi.IsDir() {
 				return nil
 			}
 			if strings.HasPrefix(fi.Name(), ".") {
@@ -128,7 +128,7 @@ func GetGopathGoPackages(out chan<- *GoPackage) {
 		}
 
 		_ = filepath.Walk(root, func(path string, fi os.FileInfo, _ error) error {
-			if !fi.IsDir() {
+			if fi == nil || !fi.IsDir() {
 				return nil
 			}
 			if strings.HasPrefix(fi.Name(), ".") {


### PR DESCRIPTION
Fixes an error occured when I tried to use Go-Package-Store.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x14 pc=0x5d50a5]

goroutine 35 [running]:
runtime.panic(0x7252c0, 0x95a1e2)
        c:/go/src/pkg/runtime/panic.c:279 +0xe9
github.com/shurcooL/go/gists/gist8018045.func┬Ě003(0x12851680, 0x108, 0x0, 0x0, 0x250200, 0x1284da40, 0x0, 0x0)
        D:/backup/go/src/github.com/shurcooL/go/gists/gist8018045/main.go:131 +0x65
```

Anyway, after this fix its scanning and server is shut down - doesnt work, but nil pointer dereference is fixed.
