### PR TITLE
Whitespace is its own token. Don't glom it onto the next token.

### DIFF
--- a/highlight_go/main.go
+++ b/highlight_go/main.go
@@ -63,9 +63,11 @@ func Print(src []byte, w io.Writer, p syntaxhighlight.Printer) error {
 		// TODO: Clean this up.
 		whitespace := string(src[lastOffset:offset])
 		lastOffset = offset + len(tokString)
-		tokString = whitespace + tokString
-
-		err := p.Print(w, TokenKind(tok, lit), tokString)
+		err := p.Print(w, syntaxhighlight.Whitespace, whitespace)
+		if err != nil {
+			return err
+		}
+		err = p.Print(w, TokenKind(tok, lit), tokString)
 		if err != nil {
 			return err
 		}

--- a/highlight_go/main_test.go
+++ b/highlight_go/main_test.go
@@ -1,0 +1,75 @@
+package highlight_go_test
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/shurcooL/go/gists/gist6418290"
+	"github.com/shurcooL/go/highlight_go"
+	"github.com/sourcegraph/syntaxhighlight"
+)
+
+// debugPrinter implements syntaxhighlight.Printer and prints the parameters its given.
+type debugPrinter struct{}
+
+func (debugPrinter) Print(w io.Writer, kind syntaxhighlight.Kind, tokText string) error {
+	fmt.Println(gist6418290.GetParentFuncArgsAsString(w, kind, tokText))
+
+	return nil
+}
+
+func ExamplePrint() {
+	src := []byte(`package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hey there, Go.")
+}
+`)
+
+	// debugPrinter implements syntaxhighlight.Printer and prints the parameters its given.
+	p := debugPrinter{}
+
+	highlight_go.Print(src, nil, p)
+
+	// Output:
+	// Print(<nil>, syntaxhighlight.Keyword, "package")
+	// Print(<nil>, syntaxhighlight.Whitespace, " ")
+	// Print(<nil>, syntaxhighlight.Plaintext, "main")
+	// Print(<nil>, syntaxhighlight.Whitespace, "\n\n")
+	// Print(<nil>, syntaxhighlight.Keyword, "import")
+	// Print(<nil>, syntaxhighlight.Whitespace, " ")
+	// Print(<nil>, syntaxhighlight.String, "\"fmt\"")
+	// Print(<nil>, syntaxhighlight.Whitespace, "\n\n")
+	// Print(<nil>, syntaxhighlight.Keyword, "func")
+	// Print(<nil>, syntaxhighlight.Whitespace, " ")
+	// Print(<nil>, syntaxhighlight.Plaintext, "main")
+	// Print(<nil>, syntaxhighlight.Plaintext, "(")
+	// Print(<nil>, syntaxhighlight.Plaintext, ")")
+	// Print(<nil>, syntaxhighlight.Whitespace, " ")
+	// Print(<nil>, syntaxhighlight.Plaintext, "{")
+	// Print(<nil>, syntaxhighlight.Whitespace, "\n\t")
+	// Print(<nil>, syntaxhighlight.Plaintext, "fmt")
+	// Print(<nil>, syntaxhighlight.Plaintext, ".")
+	// Print(<nil>, syntaxhighlight.Plaintext, "Println")
+	// Print(<nil>, syntaxhighlight.Plaintext, "(")
+	// Print(<nil>, syntaxhighlight.String, "\"Hey there, Go.\"")
+	// Print(<nil>, syntaxhighlight.Plaintext, ")")
+	// Print(<nil>, syntaxhighlight.Whitespace, "\n")
+	// Print(<nil>, syntaxhighlight.Plaintext, "}")
+	// Print(<nil>, syntaxhighlight.Whitespace, "\n")
+}
+
+func ExamplePrintWhitespace() {
+	src := []byte("  package    main      \n\t\n")
+
+	highlight_go.Print(src, nil, debugPrinter{})
+
+	// Output:
+	// Print(<nil>, syntaxhighlight.Whitespace, "  ")
+	// Print(<nil>, syntaxhighlight.Keyword, "package")
+	// Print(<nil>, syntaxhighlight.Whitespace, "    ")
+	// Print(<nil>, syntaxhighlight.Plaintext, "main")
+	// Print(<nil>, syntaxhighlight.Whitespace, "      \n\t\n")
+}


### PR DESCRIPTION
 I tried go_highlight_go and would like to use it but I am concerned of one thing. In early versions where keywords were underlined I noticed that the attributes for white space before the token is taken from the subsequent token. So rather than:

<pre>
/* hello world*/
<strike>var</strike> a = 3;
</pre>

we'd get: 

<pre>
/* hello world*/<strike>   
var</strike> a = 3;
</pre>

(I use strike above, because I can't figure out how to underline text in markdown.)

The attached pull request addresses this.   

Also, I'd like to see more a finer grained breakout of the token. For example: 

* Whitespace
* Comment
* Keyword           
* Type name 
* Built in 
* Function   
* Variable 
* Exported name     
*  Case label
* Number
* String
* Rune

Of course a particular style is free not make such distinction in typeface or color for these, but that would be up to the styler's choice. From the standpoint of the package it would be good to provide this. 

However I realize that this is an issue with github.com/sourcegraph/syntaxhighlight, so I'll bring it up there.





     