### PR TITLE
Add union filesystem that can mount multiple filesystems.

### DIFF
--- a/vfs/httpfs/union/union.go
+++ b/vfs/httpfs/union/union.go
@@ -1,0 +1,115 @@
+// Package union offers a simple http.FileSystem that can unify multiple filesystems at various mount points.
+package union
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// New creates an union filesystem with the provided mapping of mount points to filesystems.
+//
+// Each mount point must be of form "/mydir". It must start with a '/', and contain a single directory name.
+func New(mapping map[string]http.FileSystem) http.FileSystem {
+	u := &unionFS{
+		ns: make(map[string]http.FileSystem),
+		root: &dirInfo{
+			name:    "/",
+			entries: []os.FileInfo{}, // Not nil.
+			modTime: time.Time{},     // TODO: What should this time be?
+		},
+	}
+	for mountPoint, fs := range mapping {
+		u.bind(mountPoint, fs)
+	}
+	return u
+}
+
+type unionFS struct {
+	ns   map[string]http.FileSystem // Key is mount point, e.g., "/mydir".
+	root *dirInfo
+}
+
+// bind mounts fs at mountPoint.
+// mountPoint must be of form "/mydir". It must start with a '/', and contain a single directory name.
+func (u *unionFS) bind(mountPoint string, fs http.FileSystem) {
+	u.ns[mountPoint] = fs
+	u.root.entries = append(u.root.entries, &dirInfo{
+		name:    mountPoint[1:],
+		entries: nil,         // entries is nil, not needed because this acts as a os.FileInfo only, not an openable dir.
+		modTime: time.Time{}, // TODO: What should this time be?
+	})
+}
+
+// Open opens the named file.
+func (u *unionFS) Open(path string) (http.File, error) {
+	// TODO: Maybe clean path?
+	if path == "/" {
+		return &dir{
+			dirInfo: u.root,
+		}, nil
+	}
+	for prefix, fs := range u.ns {
+		if path == prefix || strings.HasPrefix(path, prefix+"/") {
+			innerPath := path[len(prefix):]
+			if innerPath == "" {
+				innerPath = "/"
+			}
+			return fs.Open(innerPath)
+		}
+	}
+	return nil, &os.PathError{Op: "open", Path: path, Err: os.ErrNotExist}
+}
+
+// dirInfo is a static definition of a directory.
+type dirInfo struct {
+	name    string
+	entries []os.FileInfo // Not nil.
+	modTime time.Time
+}
+
+func (d *dirInfo) Read([]byte) (int, error) {
+	return 0, fmt.Errorf("cannot Read from directory %s", d.name)
+}
+func (d *dirInfo) Close() error               { return nil }
+func (d *dirInfo) Stat() (os.FileInfo, error) { return d, nil }
+
+func (d *dirInfo) Name() string       { return d.name }
+func (d *dirInfo) Size() int64        { return 0 }
+func (d *dirInfo) Mode() os.FileMode  { return 0755 | os.ModeDir }
+func (d *dirInfo) ModTime() time.Time { return d.modTime }
+func (d *dirInfo) IsDir() bool        { return true }
+func (d *dirInfo) Sys() interface{}   { return nil }
+
+// dir is an opened dir instance.
+type dir struct {
+	*dirInfo
+	pending []os.FileInfo
+}
+
+func (d *dir) Seek(offset int64, whence int) (int64, error) {
+	if offset == 0 && whence == os.SEEK_SET {
+		d.pending = nil
+		return 0, nil
+	}
+	return 0, fmt.Errorf("unsupported Seek in directory %s", d.dirInfo.name)
+}
+
+func (d *dir) Readdir(count int) ([]os.FileInfo, error) {
+	if d.pending == nil {
+		d.pending = d.dirInfo.entries
+	}
+
+	if len(d.pending) == 0 && count > 0 {
+		return nil, io.EOF
+	}
+	if count <= 0 || count > len(d.pending) {
+		count = len(d.pending)
+	}
+	e := d.pending[:count]
+	d.pending = d.pending[count:]
+	return e, nil
+}

--- a/vfs/httpfs/union/union_test.go
+++ b/vfs/httpfs/union/union_test.go
@@ -1,0 +1,80 @@
+package union_test
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/shurcooL/go/vfs/httpfs/union"
+	"github.com/shurcooL/go/vfs/httpfs/vfsutil"
+	"golang.org/x/tools/godoc/vfs/httpfs"
+	"golang.org/x/tools/godoc/vfs/mapfs"
+)
+
+func walk(path string, fi os.FileInfo, err error) error {
+	if err != nil {
+		log.Printf("can't stat file %s: %v\n", path, err)
+		return nil
+	}
+	fmt.Println(path)
+	return nil
+}
+
+func Example() {
+	fs0 := httpfs.New(mapfs.New(map[string]string{
+		"zzz-last-file.txt":   "It should be visited last.",
+		"a-file.txt":          "It has stuff.",
+		"another-file.txt":    "Also stuff.",
+		"folderA/entry-A.txt": "Alpha.",
+		"folderA/entry-B.txt": "Beta.",
+	}))
+	fs1 := httpfs.New(mapfs.New(map[string]string{
+		"sample-file.txt":                "This file compresses well. Blaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaah!",
+		"not-worth-compressing-file.txt": "Its normal contents are here.",
+		"folderA/file1.txt":              "Stuff 1.",
+		"folderA/file2.txt":              "Stuff 2.",
+		"folderB/folderC/file3.txt":      "Stuff C-3.",
+	}))
+
+	fs := union.New(map[string]http.FileSystem{
+		"/fs0": fs0,
+		"/fs1": fs1,
+	})
+
+	err := vfsutil.Walk(fs, "/", walk)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// /
+	// /fs0
+	// /fs0/a-file.txt
+	// /fs0/another-file.txt
+	// /fs0/folderA
+	// /fs0/folderA/entry-A.txt
+	// /fs0/folderA/entry-B.txt
+	// /fs0/zzz-last-file.txt
+	// /fs1
+	// /fs1/folderA
+	// /fs1/folderA/file1.txt
+	// /fs1/folderA/file2.txt
+	// /fs1/folderB
+	// /fs1/folderB/folderC
+	// /fs1/folderB/folderC/file3.txt
+	// /fs1/not-worth-compressing-file.txt
+	// /fs1/sample-file.txt
+}
+
+func ExampleEmpty() {
+	empty := union.New(nil)
+
+	err := vfsutil.Walk(empty, "/", walk)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// /
+}


### PR DESCRIPTION
It's a very simple package that uses `http.FileSystem` interface. It can only mount filesystems at initialization, and each mounted filesystem is mounted onto a single unique directory in root.