### PR TITLE
add 'generated' to analysis.IsFileGenerated

### DIFF
--- a/analysis/generated_detection.go
+++ b/analysis/generated_detection.go
@@ -21,6 +21,8 @@ func IsFileGenerated(rootDir, name string) (bool, error) {
 		return true, nil
 	case strings.HasPrefix(name, "Godeps/"):
 		return true, nil
+	case strings.Contains(name, "generated"):
+		return true, nil
 	}
 
 	// Detect from file contents.

--- a/analysis/generated_detection_test.go
+++ b/analysis/generated_detection_test.go
@@ -18,11 +18,13 @@ func ExampleIsFileGenerated() {
 	fmt.Println(analysis.IsFileGenerated(cwd, "testdata/handcrafted_1.go.txt"))
 	fmt.Println(analysis.IsFileGenerated(cwd, "vendor/github.com/shurcooL/go/analysis/file.go"))
 	fmt.Println(analysis.IsFileGenerated(cwd, "subpkg/vendor/math/math.go"))
+	fmt.Println(analysis.IsFileGenerated(cwd, "pkg/templates_generated.go"))
 
 	// Output:
 	// true <nil>
 	// false <nil>
 	// false <nil>
+	// true <nil>
 	// true <nil>
 	// true <nil>
 }


### PR DESCRIPTION
Saw https://github.com/bradleyfalzon/gopherci/pull/67 (at long last), and found the function it was using here -> I'm not sure if adding this check is a completely good idea, as it may be a better idea to fix the generators (I have a few cases where this change helps)

Thoughts?

Also relevant - https://github.com/golang/go/issues/13560

cc/ @bradleyfalzon 